### PR TITLE
fix module 're' has no attribute '_pattern_type' in python 3.7

### DIFF
--- a/conseq/parser/__init__.py
+++ b/conseq/parser/__init__.py
@@ -27,7 +27,12 @@ FileRef = namedtuple("FileRef", "filename")
 
 class CustomRuleEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, re._pattern_type):
+        try:
+            pattern = re._pattern_type
+        except AttributeError:
+            # Python 3.7
+            pattern = re.Pattern
+        if isinstance(obj, pattern):
             return {"re_pattern": obj.pattern}
         # Let the base class default method raise the TypeError
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
@pgm, do you expect that the conseq taiga id re-writing should work on master? I ran into the error below, which seems to suggest that the CustomRuleEncoder stuff doesn't work with python 3.7. Which surprised me cos I would assume that that's what you dev-ed on.

This PR fixes that. I made it a try/catch cos I'm not sure if conseq should also run on python < 3.7?

Also, how is the conseq version for the portal pipeline specified?

Stacktrace from error:
```
(depmap) lm64f-c74:pipeline jshlee$ conseq run run_internal.conseq --confirm
Namespace(addlabel=None, concurrent=1, config='~/.conseq', confirm=True, dir='state', file='run_internal.conseq', func=<function add_run.<locals>.run_cmd at 0x10eaf2c20>, maxfail=1, maxstart=None, nocapture=False, nothing=False, overrides=None, reattach_existing=None, remove_unknown_artifacts=None, targets=[], verbose=False)
Traceback (most recent call last):
  File "/Users/jshlee/opt/anaconda3/envs/depmap/bin/conseq", line 11, in <module>
    load_entry_point('conseq', 'console_scripts', 'conseq')()
  File "/Users/jshlee/conseq/conseq/main.py", line 272, in conseq_command_entry
    ret = main()
  File "/Users/jshlee/conseq/conseq/main.py", line 318, in main
    return args.func(args)
  File "/Users/jshlee/conseq/conseq/main.py", line 172, in run_cmd
    properties_to_add=properties_to_add)
  File "/Users/jshlee/conseq/conseq/depexec.py", line 765, in main
    rule_specifications = rules.get_rule_specifications()
  File "/Users/jshlee/conseq/conseq/config.py", line 23, in get_rule_specifications
    result[transform] = instance.to_json()
  File "/Users/jshlee/conseq/conseq/parser/__init__.py", line 56, in to_json
    }, sort_keys=True, cls=CustomRuleEncoder)
  File "/Users/jshlee/opt/anaconda3/envs/depmap/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/Users/jshlee/opt/anaconda3/envs/depmap/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/jshlee/opt/anaconda3/envs/depmap/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Users/jshlee/conseq/conseq/parser/__init__.py", line 30, in default
    if isinstance(obj, re._pattern_type):
AttributeError: module 're' has no attribute '_pattern_type'
```